### PR TITLE
Fix typo on log file variable

### DIFF
--- a/src/init.sh
+++ b/src/init.sh
@@ -32,5 +32,5 @@ function init_log() {
 
     touch "${LOG_FILE}"
     echo -e "Commit hash: $(git rev-parse HEAD)" >>"${LOG_FILE}"
-    echo -e "Log file: ${LOGFILE}\n" >>"${LOG_FILE}"
+    echo -e "Log file: ${LOG_FILE}\n" >>"${LOG_FILE}"
 }


### PR DESCRIPTION
On the created log file, its own name was not recorded.
