### PR TITLE
Add support for Trizen as AUR manager

### DIFF
--- a/src/system/config/aur.sh
+++ b/src/system/config/aur.sh
@@ -7,16 +7,18 @@ function install_aur() {
     local -r git_url=(
         "https://aur.archlinux.org/yay-bin.git"
         "https://aur.archlinux.org/paru-bin.git"
+        "https://aur.archlinux.org/trizen.git"
     )
     local -r aur_name=(
         "yay-bin"
         "paru-bin"
+        "trizen"
     )
     local id=-1
     local choice=""
 
-    while [[ $choice != "yay" && $choice != "paru" ]]; do
-        read -rp "$(eval_gettext "which aur helper do you want to install ? (yay/paru) : ")" choice
+    while [[ $choice != "yay" && $choice != "paru" && $choice != "trizen" ]]; do
+        read -rp "$(eval_gettext "which aur helper do you want to install ? (yay/paru/trizen) : ")" choice
         choice="${choice,,}"
     done
     eval_gettext "\${GREEN}You chose \${choice}\${RESET}"; echo
@@ -27,6 +29,9 @@ function install_aur() {
     elif [[ $choice == "paru" ]]; then
         id=1
         export AUR="paru"
+    elif [[ $choice == "trizen" ]]; then
+    	id=2
+        export AUR="trizen"
     fi
 
     if ! pacman -Qi "${AUR}" &>/dev/null; then


### PR DESCRIPTION
[Trizen](https://aur.archlinux.org/packages/trizen) is a well-known, lightweight and fast AUR manager running on Perl. It uses the same commands as pacman to manage packages. I use it on my system and I think its addition would be relevant as it is a good alternative to other managers such as Paru or Yay. It works as is and doesn't require any post-installation configuration (although it is possible to change a few parameters in its file located in `~/.config/trizen/trizen.conf`) or commands to generate a database like the others since it relies on the pacman database.